### PR TITLE
Add retry logic for connection timeouts

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	portRange    string
 	timeoutSec   int
 	concurrency  int
+	maxRetries   int
 	outputFormat string
 	outputFile   string
 	verbose      bool
@@ -41,6 +42,7 @@ func init() {
 	flag.StringVar(&portRange, "range", "", "Port range to scan (e.g., 1-1000)")
 	flag.IntVar(&timeoutSec, "timeout", 2, "Connection timeout in seconds")
 	flag.IntVar(&concurrency, "concurrency", 50, "Number of concurrent connections")
+	flag.IntVar(&maxRetries, "max-retries", 3, "Maximum retry attempts for connection timeouts")
 	flag.StringVar(&outputFormat, "format", "text", "Output format: text, json, csv")
 	flag.StringVar(&outputFile, "output", "", "Output file path (default: stdout)")
 	flag.BoolVar(&verbose, "verbose", false, "Enable verbose output")
@@ -86,6 +88,7 @@ func main() {
 		fmt.Printf("Ports: %d ports to scan\n", len(ports))
 		fmt.Printf("Timeout: %v\n", timeout)
 		fmt.Printf("Concurrency: %d\n", concurrency)
+		fmt.Printf("Max Retries: %d\n", maxRetries)
 		fmt.Println(strings.Repeat("-", 50))
 	}
 
@@ -109,6 +112,7 @@ func main() {
 		Concurrency:   concurrency,
 		Verbose:       verbose,
 		ServiceDetect: serviceDetect,
+		MaxRetries:    maxRetries,
 	}
 
 	netScanner := scanner.NewNetworkScanner(scannerConfig)
@@ -137,12 +141,12 @@ func main() {
 	}
 
 	reportData := report.ReportData{
-		Target:        targetHost,
-		TargetIP:      ipAddr,
-		ScanTime:      time.Now(),
-		OpenPorts:     results.OpenPorts,
-		ClosedPorts:   results.ClosedPorts,
-		FilteredPorts: results.FilteredPorts,
+		Target:          targetHost,
+		TargetIP:        ipAddr,
+		ScanTime:        time.Now(),
+		OpenPorts:       results.OpenPorts,
+		ClosedPorts:     results.ClosedPorts,
+		FilteredPorts:   results.FilteredPorts,
 		Vulnerabilities: vulnerabilities,
 	}
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -53,6 +53,7 @@ type Config struct {
 	Concurrency   int
 	Verbose       bool
 	ServiceDetect bool
+	MaxRetries    int
 }
 
 type NetworkScanner struct {
@@ -68,6 +69,9 @@ func NewNetworkScanner(config Config) *NetworkScanner {
 	}
 	if config.Timeout <= 0 {
 		config.Timeout = 2 * time.Second
+	}
+	if config.MaxRetries <= 0 {
+		config.MaxRetries = 3
 	}
 
 	return &NetworkScanner{
@@ -151,6 +155,35 @@ func (s *NetworkScanner) Scan() (*ScanResults, error) {
 }
 
 func (s *NetworkScanner) scanPort(port int) PortResult {
+	var result PortResult
+	var lastErr error
+
+	for attempt := 0; attempt < s.config.MaxRetries; attempt++ {
+		if s.IsStopped() {
+			return PortResult{Port: port, Status: PortFiltered}
+		}
+
+		result = s.scanPortOnce(port)
+		lastErr = nil
+
+		// If port is open or closed, no need to retry
+		if result.Status == PortOpen || result.Status == PortClosed {
+			return result
+		}
+
+		// Only retry on timeout (filtered)
+		if result.Status == PortFiltered {
+			// Small delay before retry to avoid overwhelming the network
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+	}
+
+	_ = lastErr
+	return result
+}
+
+func (s *NetworkScanner) scanPortOnce(port int) PortResult {
 	startTime := time.Now()
 
 	address := fmt.Sprintf("%s:%d", s.config.TargetIP, port)
@@ -250,6 +283,7 @@ func QuickScan(host string, ports []int, timeout time.Duration) (*ScanResults, e
 		Timeout:     timeout,
 		Concurrency: 100,
 		Verbose:     false,
+		MaxRetries:  3,
 	}
 
 	scanner := NewNetworkScanner(config)


### PR DESCRIPTION
Implemented retry logic in the port scanning mechanism to handle connection timeouts more gracefully. The scanner now retries failed connections up to 3 times before marking a port as filtered, reducing false positives from transient network issues. This improves scan reliability especially in high-latency or congested network environments. closes #2